### PR TITLE
Fixed issues with ysl.json

### DIFF
--- a/gapps/ysl.json
+++ b/gapps/ysl.json
@@ -12,7 +12,7 @@
       "size": "1256958642",
       "datetime": 1605117627,
       "id": "e05675cff95f3517785dca54ef8444e14ac2bb67e558fbef4a7dc4a5f5f3fd04",
-      "url": "https://sourceforge.net/projects/havoc-os/files/ysl/Havoc-OS-v3.1>
+      "url": "https://sourceforge.net/projects/havoc-os/files/ysl/Havoc-OS-v3.1>",
       "group": "https://t.me/havoc_ysl",
       "changelog": ""
     }


### PR DESCRIPTION
File `gapps/ysl.json` lacked `",` at the end of `url`, which caused my parser to fail. I created this pull request to fix it.